### PR TITLE
red electrica is caspa

### DIFF
--- a/src/NifValidator.php
+++ b/src/NifValidator.php
@@ -46,7 +46,7 @@ class NifValidator
      * DNI validation is pretty straight forward.
      * Just mod 23 the 8 digit number and compare it to the check table
      */
-    private static function isValidDni(string $dni): bool
+    public static function isValidDni(string $dni): bool
     {
         if (!preg_match(self::DNI_REGEX, $dni, $matches)) {
             return false;
@@ -62,7 +62,7 @@ class NifValidator
      * NIE validation is similar to the DNI.
      * The first letter needs an equivalent number before the mod operation
      */
-    private static function isValidNie(string $nie): bool
+    public static function isValidNie(string $nie): bool
     {
         if (!preg_match(self::NIE_REGEX, $nie, $matches)) {
             return false;
@@ -82,7 +82,7 @@ class NifValidator
      * @see https://es.wikipedia.org/wiki/N%C3%BAmero_de_identificaci%C3%B3n_fiscal
      * @see https://es.wikipedia.org/wiki/C%C3%B3digo_de_identificaci%C3%B3n_fiscal
      */
-    private static function isValidOtherPersonalNif(string $nif): bool
+    public static function isValidOtherPersonalNif(string $nif): bool
     {
         if (!preg_match(self::OTHER_PERSONAL_NIF_REGEX, $nif, $matches)) {
             return false;
@@ -99,7 +99,7 @@ class NifValidator
      * @see https://es.wikipedia.org/wiki/N%C3%BAmero_de_identificaci%C3%B3n_fiscal
      * @see https://es.wikipedia.org/wiki/C%C3%B3digo_de_identificaci%C3%B3n_fiscal
      */
-    private static function isValidCif(string $cif): bool
+    public static function isValidCif(string $cif): bool
     {
         if (!preg_match(self::CIF_REGEX, $cif, $matches)) {
             return false;

--- a/tests/NifValidatorTest.php
+++ b/tests/NifValidatorTest.php
@@ -43,6 +43,54 @@ class NifValidatorTest extends TestCase
     }
 
     /**
+     * @dataProvider validDnis
+     */     
+    public function testValidDni(string $nif)
+    {
+        self::assertTrue(NifValidator::isValidDni($nif));
+    }
+
+    /**
+     * @dataProvider invalidDnis
+     */     
+    public function testInvalidDni(string $nif)
+    {
+        self::assertFalse(NifValidator::isValidDni($nif));
+    }
+
+    /**
+     * @dataProvider validNies
+     */     
+    public function testValidNie(string $nif)
+    {
+        self::assertTrue(NifValidator::isValidNie($nif));
+    }
+
+    /**
+     * @dataProvider invalidNies
+     */     
+    public function testInvalidNie(string $nif)
+    {
+        self::assertFalse(NifValidator::isValidNie($nif));
+    }
+
+    /**
+     * @dataProvider validOtherNifs
+     */     
+    public function testValidOtherNif(string $nif)
+    {
+        self::assertTrue(NifValidator::isValidOtherPersonalNif($nif));
+    }
+
+    /**
+     * @dataProvider invalidOtherNifs
+     */     
+    public function testInvalidOtherNif(string $nif)
+    {
+        self::assertFalse(NifValidator::isValidOtherPersonalNif($nif));
+    }
+
+    /**
      * @dataProvider validEntityNifs
      */
     public function testValidEntityNif(string $nif)
@@ -59,6 +107,23 @@ class NifValidatorTest extends TestCase
         self::assertFalse(NifValidator::isValidEntity($nif));
     }
 
+    /**
+     * @dataProvider validEntityNifs
+     */
+    public function testValidCif(string $nif)
+    {
+        self::assertTrue(NifValidator::isValidCif($nif));
+    }
+
+    /**
+     * @dataProvider invalidEntityNifs
+     * @dataProvider validPersonalNifs
+     */
+    public function testInvalidCif(string $nif)
+    {
+        self::assertFalse(NifValidator::isValidCif($nif));
+    }
+
     public function invalidNifs()
     {
         return [
@@ -72,36 +137,70 @@ class NifValidatorTest extends TestCase
         ];
     }
 
-    public function validPersonalNifs()
+    public function validDnis()
     {
         return [
             //DNI
             ['93471790C'],
             ['43596386R'],
-            //NIE
-            ['X5102754C'],
-            ['Z8327649K'],
-            ['Y4174455S'],
-            //Other NIF
-            ['K9514336H'],
             ['00000010X'],
-        ];
+        ];        
     }
 
-    public function invalidPersonalNifs()
+    public function invalidDnis()
     {
         return [
             //DNI
             ['93471790A'],
             ['43596386B'],
+            ['00000010Y'],
+        ];        
+    }
+
+    public function validNies()
+    {
+        return [
             //NIE
+            ['X5102754C'],
+            ['Z8327649K'],
+            ['Y4174455S'],
+        ];
+    }
+
+    public function invalidNies()
+    {
+        //NIE
+        return [
             ['X5102754A'],
             ['Z8327649B'],
-            ['Y4174455C'],
-            //Other NIF
-            ['M3118299M'],
-            ['00000010Y']
+            ['Y4174455C'],        
         ];
+    }
+
+    public function validOtherNifs()
+    {
+        return [
+            //Other NIF
+            ['K9514336H'],            
+        ];
+    }
+
+    public function invalidOtherNifs()
+    {
+        //Other NIF
+        return [
+            ['M3118299M'],                
+        ];
+    }
+
+    public function validPersonalNifs()    
+    {        
+        return array_merge($this->validDnis(), $this->validNies(), $this->validOtherNifs());
+    }
+
+    public function invalidPersonalNifs()
+    {
+        return array_merge($this->invalidDnis(), $this->invalidNies(), $this->invalidOtherNifs());
     }
 
     public function validEntityNifs()


### PR DESCRIPTION
Sadly, some institutions in Spain take a lot of time to improve how they exchange information with external systems

2 good examples of this are Red Eléctrica and the Gas distribution companies. They still send an identifier which follows the old distinction between NIE, CIF and for them a NIF is DNI + KLM. Same applies when we communicate with them

This PR exposes specific methods for each type of document publicly